### PR TITLE
ARVTreatment updates

### DIFF
--- a/input/fsh/examples.fsh
+++ b/input/fsh/examples.fsh
@@ -157,12 +157,12 @@ Description: "ARVCarePlan example"
 * activity.detail.code = $LNC#45260-7 
 * activity.detail.status = #in-progress
 * activity.detail.productCodeableConcept.text = "TDF/3TC/DTG"
+* activity.detail.extension[artRegimenSwitched].valueBoolean = false
+* activity.detail.extension[artRegimenSubstituded].valueBoolean = false
 * activity.detail.extension[artRegimenLine].valueCodeableConcept = $SCT#708255002
 * note.text = "Additional information regarding the ARV treatment prescribed"
 * note.authorReference = Reference(HIVOrganizationExample)
 * note.time = "2015-02-07T13:28:17-05:00"
-* extension[change-type].valueCodeableConcept.coding.code = #artInit
-* extension[change-type].valueCodeableConcept.coding.system = "http://openhie.org/fhir/hiv-cbs/CodeSystem/cs-art-change-type"
 
 Instance: HIVEpisodeOfCareExample
 InstanceOf: HIVEpisodeOfCare

--- a/input/fsh/examples.fsh
+++ b/input/fsh/examples.fsh
@@ -157,8 +157,6 @@ Description: "ARVCarePlan example"
 * activity.detail.code = $LNC#45260-7 
 * activity.detail.status = #in-progress
 * activity.detail.productCodeableConcept.text = "TDF/3TC/DTG"
-* activity.detail.extension[artRegimenSwitched].valueBoolean = false
-* activity.detail.extension[artRegimenSubstituded].valueBoolean = false
 * activity.detail.extension[artRegimenLine].valueCodeableConcept = $SCT#708255002
 * note.text = "Additional information regarding the ARV treatment prescribed"
 * note.authorReference = Reference(HIVOrganizationExample)
@@ -389,3 +387,45 @@ Description:  "Absolute CD4 Count Example"
 * note.authorReference = Reference(HIVOrganizationExample)
 * note.time = "2015-02-07T13:28:17-05:00"
 * performer = Reference(HIVOrganizationExample)
+
+Instance: ARVTreatmentRegimenSwitchedExample
+InstanceOf: ARVTreatment
+Usage: #example
+Title: "Regimen switched example"
+Description: "Regimen switched example"
+* status = #active
+* intent = #plan
+* subject = Reference(HIVPatientExample)
+* encounter = Reference(TargetFacilityEncounterExample)
+* period.start = "2022-12-01"
+* period.end = "2022-12-01"
+* activity.detail.kind = #MedicationRequest
+* activity.detail.code = $LNC#45260-7 
+* activity.detail.status = #in-progress
+* activity.detail.productCodeableConcept.text = "TDF/3TC/DTG"
+* activity.detail.extension[artRegimenLine].valueCodeableConcept = $SCT#708255002
+* activity.detail.extension[artRegimenSwitched].valueBoolean = true
+* note.text = "Additional information regarding the switching of the ARV regimen with another ARV regimen."
+* note.authorReference = Reference(HIVOrganizationExample)
+* note.time = "2015-02-07T13:28:17-05:00"
+
+Instance: ARVTreatmentRegimenSubstitutedExample
+InstanceOf: ARVTreatment
+Usage: #example
+Title: "Regimen substituted example"
+Description: "Regimen substituted example"
+* status = #active
+* intent = #plan
+* subject = Reference(HIVPatientExample)
+* encounter = Reference(TargetFacilityEncounterExample)
+* period.start = "2022-12-01"
+* period.end = "2022-12-01"
+* activity.detail.kind = #MedicationRequest
+* activity.detail.code = $LNC#45260-7 
+* activity.detail.status = #in-progress
+* activity.detail.productCodeableConcept.text = "TDF/3TC/DTG"
+* activity.detail.extension[artRegimenLine].valueCodeableConcept = $SCT#708255002
+* activity.detail.extension[artRegimenSubstituded].valueBoolean = true
+* note.text = "Additional information regarding the substitution of the ARV regimen by another ARV regimen."
+* note.authorReference = Reference(HIVOrganizationExample)
+* note.time = "2015-02-07T13:28:17-05:00"

--- a/input/fsh/examples.fsh
+++ b/input/fsh/examples.fsh
@@ -388,11 +388,11 @@ Description:  "Absolute CD4 Count Example"
 * note.time = "2015-02-07T13:28:17-05:00"
 * performer = Reference(HIVOrganizationExample)
 
-Instance: ARVTreatmentRegimenSwitchedExample
+Instance: ARVTreatmentRegimenSwitchedOrSubstitutedExample
 InstanceOf: ARVTreatment
 Usage: #example
-Title: "Regimen switched example"
-Description: "Regimen switched example"
+Title: "ARV Regimen switched or substituted example"
+Description: "ARV Regimen switched or substituted example"
 * status = #active
 * intent = #plan
 * subject = Reference(HIVPatientExample)
@@ -404,28 +404,8 @@ Description: "Regimen switched example"
 * activity.detail.status = #in-progress
 * activity.detail.productCodeableConcept.text = "TDF/3TC/DTG"
 * activity.detail.extension[artRegimenLine].valueCodeableConcept = $SCT#708255002
-* activity.detail.extension[artRegimenSwitched].valueBoolean = true
+* activity.detail.extension[artRegimenSwitchedOrSubstituted].valueCodeableConcept.coding.code = #Switched
+* activity.detail.extension[artRegimenSwitchedOrSubstituted].valueCodeableConcept.coding.system = "http://openhie.org/fhir/hiv-cbs/CodeSystem/cs-art-regimen-change-type"
 * note.text = "Additional information regarding the switching of the ARV regimen with another ARV regimen."
-* note.authorReference = Reference(HIVOrganizationExample)
-* note.time = "2015-02-07T13:28:17-05:00"
-
-Instance: ARVTreatmentRegimenSubstitutedExample
-InstanceOf: ARVTreatment
-Usage: #example
-Title: "Regimen substituted example"
-Description: "Regimen substituted example"
-* status = #active
-* intent = #plan
-* subject = Reference(HIVPatientExample)
-* encounter = Reference(TargetFacilityEncounterExample)
-* period.start = "2022-12-01"
-* period.end = "2022-12-01"
-* activity.detail.kind = #MedicationRequest
-* activity.detail.code = $LNC#45260-7 
-* activity.detail.status = #in-progress
-* activity.detail.productCodeableConcept.text = "TDF/3TC/DTG"
-* activity.detail.extension[artRegimenLine].valueCodeableConcept = $SCT#708255002
-* activity.detail.extension[artRegimenSubstituded].valueBoolean = true
-* note.text = "Additional information regarding the substitution of the ARV regimen by another ARV regimen."
 * note.authorReference = Reference(HIVOrganizationExample)
 * note.time = "2015-02-07T13:28:17-05:00"

--- a/input/fsh/examples.fsh
+++ b/input/fsh/examples.fsh
@@ -161,6 +161,8 @@ Description: "ARVCarePlan example"
 * note.text = "Additional information regarding the ARV treatment prescribed"
 * note.authorReference = Reference(HIVOrganizationExample)
 * note.time = "2015-02-07T13:28:17-05:00"
+* extension[change-type].valueCodeableConcept.coding.code = #artInit
+* extension[change-type].valueCodeableConcept.coding.system = "http://openhie.org/fhir/hiv-cbs/CodeSystem/cs-art-change-type"
 
 Instance: HIVEpisodeOfCareExample
 InstanceOf: HIVEpisodeOfCare
@@ -322,29 +324,6 @@ Description: "HIV Lab Results Diagnostic Report example"
 * performer = Reference(PractitionerExample)
 * result = Reference(HIVTestResultExample)
 * conclusion = "Some conclusion text"
-
-Instance: ARVTreatmentRefusedExample
-InstanceOf: ARVTreatment
-Usage: #example
-Title: "ARVCarePlan Refused example"
-Description: "ARVCarePlan Refused example"
-* status = #active
-* intent = #plan
-* subject = Reference(HIVPatientExample)
-* encounter = Reference(TargetFacilityEncounterExample)
-* period.start = "2021-12-01"
-* period.end = "2022-12-01"
-* activity.outcomeCodeableConcept = $SCT#105480006
-* activity.detail.kind = #MedicationRequest
-* activity.detail.code = $LNC#45260-7 
-* activity.detail.status = #stopped
-* activity.detail.productCodeableConcept.text = "TDF/3TC/DTG"
-* activity.detail.scheduledPeriod.start = "2022-06-01"
-* activity.detail.scheduledPeriod.end = "2022-06-01"
-* activity.detail.extension[artRegimenLine].valueCodeableConcept = $SCT#708255002
-* note.text = "Patient stopped treatment"
-* note.authorReference = Reference(HIVOrganizationExample)
-* note.time = "2022-02-07T13:28:17-05:00"
 
 Instance: HIVRecencyTestDoneExample
 InstanceOf: HIVRecencyTestDone

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -134,8 +134,8 @@ Description: "This profile is to record prescribed ARV regimen against a given t
 * activity.detail.code from VSARVMedicationRequest (required)
 * activity.detail.status 1..1
 * activity.detail.productCodeableConcept 1..1 
-* activity.detail.extension contains ARTRegimenSwitched named artRegimenSwitched 1..1
-* activity.detail.extension contains ARTRegimenSubstituded named artRegimenSubstituded 1..1
+* activity.detail.extension contains ARTRegimenSwitched named artRegimenSwitched 0..1 MS
+* activity.detail.extension contains ARTRegimenSubstituded named artRegimenSubstituded 0..1 MS
 * activity.detail.extension contains ARTRegimenLine named artRegimenLine 1..1
 * note 0..1
 

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -134,8 +134,7 @@ Description: "This profile is to record prescribed ARV regimen against a given t
 * activity.detail.code from VSARVMedicationRequest (required)
 * activity.detail.status 1..1
 * activity.detail.productCodeableConcept 1..1 
-* activity.detail.extension contains ARTRegimenSwitched named artRegimenSwitched 0..1 MS
-* activity.detail.extension contains ARTRegimenSubstituded named artRegimenSubstituded 0..1 MS
+* activity.detail.extension contains ARTRegimenSwitchedOrSubstituted named artRegimenSwitchedOrSubstituted 0..1 MS
 * activity.detail.extension contains ARTRegimenLine named artRegimenLine 1..1
 * note 0..1
 
@@ -146,17 +145,12 @@ Description: "Therapeutic lines that are used to classify the patient's currentl
 * value[x] only CodeableConcept
 * valueCodeableConcept from VSARTRegimenLines (required)
 
-Extension: ARTRegimenSwitched
-Id: art-regimen-switched
-Title: "ART Regimen Switched"
-Description: "The ARV regimen has been switched to a new ARV regimen."
-* value[x] only boolean
-
-Extension: ARTRegimenSubstituded
-Id: art-regimen-substituted
-Title: "ART Regimen Substituted"
-Description: "The ARV regimen has been substituded by a new ARV regimen."
-* value[x] only boolean
+Extension: ARTRegimenSwitchedOrSubstituted
+Id: art-regimen-switched-or-substituded
+Title: "ART Regimen Switched Or Substituted"
+Description: "The ARV regimen has been switched to a new ARV regimen or has been substituted by another ARV regimen."
+* value[x] only CodeableConcept
+* valueCodeableConcept from VSARTRegimenChangeType (required)
 
 Profile: HIVEpisodeOfCare
 Parent: EpisodeOfCare

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -133,10 +133,10 @@ Description: "This profile is to record prescribed ARV regimen against a given t
 * activity.detail.kind = #MedicationRequest
 * activity.detail.code from VSARVMedicationRequest (required)
 * activity.detail.status 1..1
-* activity.detail.scheduledPeriod MS
 * activity.detail.productCodeableConcept 1..1  
 * activity.detail.extension contains ARTRegimenLine named artRegimenLine 1..1
 * note 0..1
+* extension contains ARTChangeType named change-type 1..1
 
 Extension: ARTRegimenLine
 Id: art-regimen-line
@@ -336,3 +336,10 @@ Description: "This profile is for recording the Patient's CD4 Count."
 * performer 1..1
 * valueInteger 1..1
 * note 0..1
+
+Extension: ARTChangeType
+Id: art-change-type
+Title: "ART Change Type"
+Description: "A list of options to distinguish the ART between Initial, Switch and Substitute"
+* value[x] only CodeableConcept
+* valueCodeableConcept from VSARTChangeType (required)

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -146,7 +146,7 @@ Description: "Therapeutic lines that are used to classify the patient's currentl
 * valueCodeableConcept from VSARTRegimenLines (required)
 
 Extension: ARTRegimenSwitchedOrSubstituted
-Id: art-regimen-switched-or-substituded
+Id: art-regimen-switched-or-substituted
 Title: "ART Regimen Switched Or Substituted"
 Description: "The ARV regimen has been switched to a new ARV regimen or has been substituted by another ARV regimen."
 * value[x] only CodeableConcept

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -133,10 +133,11 @@ Description: "This profile is to record prescribed ARV regimen against a given t
 * activity.detail.kind = #MedicationRequest
 * activity.detail.code from VSARVMedicationRequest (required)
 * activity.detail.status 1..1
-* activity.detail.productCodeableConcept 1..1  
+* activity.detail.productCodeableConcept 1..1 
+* activity.detail.extension contains ARTRegimenSwitched named artRegimenSwitched 1..1
+* activity.detail.extension contains ARTRegimenSubstituded named artRegimenSubstituded 1..1
 * activity.detail.extension contains ARTRegimenLine named artRegimenLine 1..1
 * note 0..1
-* extension contains ARTChangeType named change-type 1..1
 
 Extension: ARTRegimenLine
 Id: art-regimen-line
@@ -144,6 +145,18 @@ Title: "ART Regimen Line"
 Description: "Therapeutic lines that are used to classify the patient's currently prescribed ARV regimen."
 * value[x] only CodeableConcept
 * valueCodeableConcept from VSARTRegimenLines (required)
+
+Extension: ARTRegimenSwitched
+Id: art-regimen-switched
+Title: "ART Regimen Switched"
+Description: "The ARV regimen has been switched to a new ARV regimen."
+* value[x] only boolean
+
+Extension: ARTRegimenSubstituded
+Id: art-regimen-substituted
+Title: "ART Regimen Substituted"
+Description: "The ARV regimen has been substituded by a new ARV regimen."
+* value[x] only boolean
 
 Profile: HIVEpisodeOfCare
 Parent: EpisodeOfCare
@@ -336,10 +349,3 @@ Description: "This profile is for recording the Patient's CD4 Count."
 * performer 1..1
 * valueInteger 1..1
 * note 0..1
-
-Extension: ARTChangeType
-Id: art-change-type
-Title: "ART Change Type"
-Description: "A list of options to distinguish the ART between Initial, Switch and Substitute"
-* value[x] only CodeableConcept
-* valueCodeableConcept from VSARTChangeType (required)

--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -179,20 +179,3 @@ Title: "CD4 test result code"
 Description:  "A list of CD4 test result codes"
 * ^experimental = false
 * $SCT#151271000119102 "Abnormal blood test (finding)"  
-
-CodeSystem: CSARTChangeType
-Id: cs-art-change-type
-Title: "ART Change Type"
-Description: "A list of options to distinguish the ART between Initial, Switch and Substitute"
-* ^experimental = false
-* ^caseSensitive = true
-* #artInit "ART Initiated"
-* #artSwitch "ART Switch"
-* #artSub "ART Substitute"
-
-ValueSet: VSARTChangeType
-Id: vs-art-change-type
-Title: "ART Change Type"
-Description: "A list of options to distinguish the ART between Initial, Switch and Substitute"
-* ^experimental = false
-* include codes from system CSARTChangeType

--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -179,3 +179,19 @@ Title: "CD4 test result code"
 Description:  "A list of CD4 test result codes"
 * ^experimental = false
 * $SCT#151271000119102 "Abnormal blood test (finding)"  
+
+CodeSystem: CSARTRegimenChangeType
+Id: cs-art-regimen-change-type
+Title: "ART Regimen Change Types"
+Description: "A list of options to determine whether an ARV regimen was switched or substituted."
+* ^experimental = false
+* ^caseSensitive = true
+* #Switched "ARV Regimen Switched"
+* #Substituted "ARV Regimen Substituted"
+
+ValueSet: VSARTRegimenChangeType
+Id: vs-art-regimen-change-type
+Title: "ART Regimen Change Types"
+Description: "A list of options to determine whether an ARV regimen was switched or substituted."
+* ^experimental = false
+* include codes from system CSARTRegimenChangeType

--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -179,3 +179,20 @@ Title: "CD4 test result code"
 Description:  "A list of CD4 test result codes"
 * ^experimental = false
 * $SCT#151271000119102 "Abnormal blood test (finding)"  
+
+CodeSystem: CSARTChangeType
+Id: cs-art-change-type
+Title: "ART Change Type"
+Description: "A list of options to distinguish the ART between Initial, Switch and Substitute"
+* ^experimental = false
+* ^caseSensitive = true
+* #artInit "ART Initiated"
+* #artSwitch "ART Switch"
+* #artSub "ART Substitute"
+
+ValueSet: VSARTChangeType
+Id: vs-art-change-type
+Title: "ART Change Type"
+Description: "A list of options to distinguish the ART between Initial, Switch and Substitute"
+* ^experimental = false
+* include codes from system CSARTChangeType


### PR DESCRIPTION
Removed ARVTreatmentRefusedExample
Removed CarePlan.activity.detail.scheduledPeriod
Add Careplan Extension for distinguish of option Initial/switch/sub
-----------------------------------------------------------------
Reason for binding a valueCodeable to extension field (instead of declaring seperate boolean fields)
--Reduce API fields exposed to clients. 
--Less use of extensions
--Group a concept
--Avoid issues like receiving invalid combinations from a Client
--These options are mutually exclusive